### PR TITLE
Unity6 upgrade

### DIFF
--- a/Editor/ScriptingDefineUtility.cs
+++ b/Editor/ScriptingDefineUtility.cs
@@ -7,23 +7,39 @@ namespace Dreamteck.Editor
     {
         public static void Add(string define, BuildTargetGroup target, bool log = false)
         {
+#if UNITY_6000_0_OR_NEWER
+            string definesString = PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(target));
+#else
             string definesString = PlayerSettings.GetScriptingDefineSymbolsForGroup(target);
+#endif
             if (definesString.Contains(define)) return;
             string[] allDefines = definesString.Split(';');
             ArrayUtility.Add(ref allDefines, define);
             definesString = string.Join(";", allDefines);
+#if UNITY_6000_0_OR_NEWER
+            PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(target), definesString);
+#else
             PlayerSettings.SetScriptingDefineSymbolsForGroup(target, definesString);
+#endif
             Debug.Log("Added \"" + define + "\" from " + EditorUserBuildSettings.selectedBuildTargetGroup + " Scripting define in Player Settings");
         }
 
         public static void Remove(string define, BuildTargetGroup target, bool log = false)
         {
+#if UNITY_6000_0_OR_NEWER
+            string definesString = PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(target));
+#else
             string definesString = PlayerSettings.GetScriptingDefineSymbolsForGroup(target);
+#endif
             if (!definesString.Contains(define)) return;
             string[] allDefines = definesString.Split(';');
             ArrayUtility.Remove(ref allDefines, define);
             definesString = string.Join(";", allDefines);
+#if UNITY_6000_0_OR_NEWER
+            PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(target), definesString);
+#else
             PlayerSettings.SetScriptingDefineSymbolsForGroup(target, definesString);
+#endif
             Debug.Log("Removed \""+ define + "\" from " + EditorUserBuildSettings.selectedBuildTargetGroup + " Scripting define in Player Settings");
         }
     }

--- a/Singleton.cs
+++ b/Singleton.cs
@@ -11,7 +11,11 @@ namespace Dreamteck
             {
                 if (_instance == null)
                 {
+#if UNITY_6000_0_OR_NEWER
+                    _instance = Object.FindObjectsByType<T>(FindObjectsSortMode.None).FirstOrDefault();
+#else
                     _instance = Object.FindObjectsOfType<T>().FirstOrDefault();
+#endif
                 }
 
                 return _instance;


### PR DESCRIPTION
`BuildTargetGroup` enum is replaced by `NamedBuildTarget` struct
`FindObjectsOfType` is replaced by `FindObjectsByType` with no sorting.